### PR TITLE
Fixed spelling in bidCutPerecentage storage mapper + updated JSON files

### DIFF
--- a/esdt-nft-marketplace/mandos/auction_end_deadline.scen.json
+++ b/esdt-nft-marketplace/mandos/auction_end_deadline.scen.json
@@ -97,7 +97,7 @@
                     "nonce": "0",
                     "balance": "0",
                     "storage": {
-                        "str:bidCutPerecentage": "1000",
+                        "str:bidCutPercentage": "1000",
                         "str:lastValidAuctionId": "1",
                         "str:auctionById|nested:str:NFT-123456|u64:1": ""
                     },

--- a/esdt-nft-marketplace/mandos/auction_end_max_bid.scen.json
+++ b/esdt-nft-marketplace/mandos/auction_end_max_bid.scen.json
@@ -90,7 +90,7 @@
                     "nonce": "0",
                     "balance": "0",
                     "storage": {
-                        "str:bidCutPerecentage": "1000",
+                        "str:bidCutPercentage": "1000",
                         "str:lastValidAuctionId": "1",
                         "str:auctionById|nested:str:NFT-123456|u64:1": ""
                     },

--- a/esdt-nft-marketplace/mandos/auction_sell_all_end_deadline.scen.json
+++ b/esdt-nft-marketplace/mandos/auction_sell_all_end_deadline.scen.json
@@ -97,7 +97,7 @@
                     "nonce": "0",
                     "balance": "0",
                     "storage": {
-                        "str:bidCutPerecentage": "1000",
+                        "str:bidCutPercentage": "1000",
                         "str:lastValidAuctionId": "1",
                         "str:auctionById|nested:str:NFT-123456|u64:1": ""
                     },

--- a/esdt-nft-marketplace/mandos/auction_sft_sell_all.scen.json
+++ b/esdt-nft-marketplace/mandos/auction_sft_sell_all.scen.json
@@ -84,7 +84,7 @@
                         }
                     },
                     "storage": {
-                        "str:bidCutPerecentage": "1000",
+                        "str:bidCutPercentage": "1000",
                         "str:lastValidAuctionId": "1",
                         "str:auctionById|u64:1": {
                             "00-auctioned_token": "nested:str:SFT-123456|u64:1",

--- a/esdt-nft-marketplace/mandos/auction_sft_sell_one_by_one.scen.json
+++ b/esdt-nft-marketplace/mandos/auction_sft_sell_one_by_one.scen.json
@@ -86,7 +86,7 @@
                         }
                     },
                     "storage": {
-                        "str:bidCutPerecentage": "1000",
+                        "str:bidCutPercentage": "1000",
                         "str:lastValidAuctionId": "1",
                         "str:auctionById|u64:1": {
                             "00-auctioned_token": "nested:str:SFT-123456|u64:1",

--- a/esdt-nft-marketplace/mandos/auction_token.scen.json
+++ b/esdt-nft-marketplace/mandos/auction_token.scen.json
@@ -84,7 +84,7 @@
                         }
                     },
                     "storage": {
-                        "str:bidCutPerecentage": "1000",
+                        "str:bidCutPercentage": "1000",
                         "str:lastValidAuctionId": "1",
                         "str:auctionById|u64:1": {
                             "00-auctioned_token": "nested:str:NFT-123456|u64:1",

--- a/esdt-nft-marketplace/mandos/auction_with_start_time.scen.json
+++ b/esdt-nft-marketplace/mandos/auction_with_start_time.scen.json
@@ -87,7 +87,7 @@
                         }
                     },
                     "storage": {
-                        "str:bidCutPerecentage": "1000",
+                        "str:bidCutPercentage": "1000",
                         "str:lastValidAuctionId": "1",
                         "str:auctionById|u64:1": {
                             "00-auctioned_token": "nested:str:NFT-123456|u64:1",
@@ -187,7 +187,7 @@
                         }
                     },
                     "storage": {
-                        "str:bidCutPerecentage": "1000",
+                        "str:bidCutPercentage": "1000",
                         "str:lastValidAuctionId": "1",
                         "str:auctionById|u64:1": {
                             "00-auctioned_token": "nested:str:NFT-123456|u64:1",

--- a/esdt-nft-marketplace/mandos/bid_first.scen.json
+++ b/esdt-nft-marketplace/mandos/bid_first.scen.json
@@ -52,7 +52,7 @@
                         }
                     },
                     "storage": {
-                        "str:bidCutPerecentage": "1000",
+                        "str:bidCutPercentage": "1000",
                         "str:lastValidAuctionId": "1",
                         "str:auctionById|u64:1": {
                             "00-auctioned_token": "nested:str:NFT-123456|u64:1",

--- a/esdt-nft-marketplace/mandos/bid_max.scen.json
+++ b/esdt-nft-marketplace/mandos/bid_max.scen.json
@@ -57,7 +57,7 @@
                         }
                     },
                     "storage": {
-                        "str:bidCutPerecentage": "1000",
+                        "str:bidCutPercentage": "1000",
                         "str:lastValidAuctionId": "1",
                         "str:auctionById|u64:1": {
                             "00-auctioned_token": "nested:str:NFT-123456|u64:1",

--- a/esdt-nft-marketplace/mandos/bid_second.scen.json
+++ b/esdt-nft-marketplace/mandos/bid_second.scen.json
@@ -57,7 +57,7 @@
                         }
                     },
                     "storage": {
-                        "str:bidCutPerecentage": "1000",
+                        "str:bidCutPercentage": "1000",
                         "str:lastValidAuctionId": "1",
                         "str:auctionById|u64:1": {
                             "00-auctioned_token": "nested:str:NFT-123456|u64:1",

--- a/esdt-nft-marketplace/mandos/bid_sft_sell_all_first.scen.json
+++ b/esdt-nft-marketplace/mandos/bid_sft_sell_all_first.scen.json
@@ -52,7 +52,7 @@
                         }
                     },
                     "storage": {
-                        "str:bidCutPerecentage": "1000",
+                        "str:bidCutPercentage": "1000",
                         "str:lastValidAuctionId": "1",
                         "str:auctionById|u64:1": {
                             "00-auctioned_token": "nested:str:SFT-123456|u64:1",

--- a/esdt-nft-marketplace/mandos/bid_sft_sell_all_second.scen.json
+++ b/esdt-nft-marketplace/mandos/bid_sft_sell_all_second.scen.json
@@ -57,7 +57,7 @@
                         }
                     },
                     "storage": {
-                        "str:bidCutPerecentage": "1000",
+                        "str:bidCutPercentage": "1000",
                         "str:lastValidAuctionId": "1",
                         "str:auctionById|u64:1": {
                             "00-auctioned_token": "nested:str:SFT-123456|u64:1",

--- a/esdt-nft-marketplace/mandos/buy_sft_sell_one_by_one.scen.json
+++ b/esdt-nft-marketplace/mandos/buy_sft_sell_one_by_one.scen.json
@@ -126,7 +126,7 @@
                         }
                     },
                     "storage": {
-                        "str:bidCutPerecentage": "1000",
+                        "str:bidCutPercentage": "1000",
                         "str:lastValidAuctionId": "1",
                         "str:auctionById|u64:1": {
                             "00-auctioned_token": "nested:str:SFT-123456|u64:1",

--- a/esdt-nft-marketplace/mandos/buy_sft_sell_one_by_one_second.scen.json
+++ b/esdt-nft-marketplace/mandos/buy_sft_sell_one_by_one_second.scen.json
@@ -115,7 +115,7 @@
                         }
                     },
                     "storage": {
-                        "str:bidCutPerecentage": "1000",
+                        "str:bidCutPercentage": "1000",
                         "str:lastValidAuctionId": "1",
                         "str:auctionById|u64:1": {
                             "00-auctioned_token": "nested:str:SFT-123456|u64:1",

--- a/esdt-nft-marketplace/mandos/init.scen.json
+++ b/esdt-nft-marketplace/mandos/init.scen.json
@@ -100,7 +100,7 @@
                     "nonce": "0",
                     "balance": "0",
                     "storage": {
-                        "str:bidCutPerecentage": "1000"
+                        "str:bidCutPercentage": "1000"
                     },
                     "code": "file:../output/esdt-nft-marketplace.wasm"
                 },

--- a/esdt-nft-marketplace/mandos/specific_token_auctioned.scen.json
+++ b/esdt-nft-marketplace/mandos/specific_token_auctioned.scen.json
@@ -106,7 +106,7 @@
                         }
                     },
                     "storage": {
-                        "str:bidCutPerecentage": "1000",
+                        "str:bidCutPercentage": "1000",
                         "str:lastValidAuctionId": "1",
                         "str:auctionById|u64:1": {
                             "00-auctioned_token": "nested:str:BBIT-1b9bb6|u64:1",

--- a/esdt-nft-marketplace/mandos/withdraw.scen.json
+++ b/esdt-nft-marketplace/mandos/withdraw.scen.json
@@ -60,7 +60,7 @@
                     "nonce": "0",
                     "balance": "0",
                     "storage": {
-                        "str:bidCutPerecentage": "1000",
+                        "str:bidCutPercentage": "1000",
                         "str:lastValidAuctionId": "1",
                         "str:auctionById|nested:str:NFT-123456|u64:1": ""
                     },

--- a/esdt-nft-marketplace/mandos/withdraw_after_end_auction.scen.json
+++ b/esdt-nft-marketplace/mandos/withdraw_after_end_auction.scen.json
@@ -111,7 +111,7 @@
                     "nonce": "0",
                     "balance": "0",
                     "storage": {
-                        "str:bidCutPerecentage": "1000",
+                        "str:bidCutPercentage": "1000",
                         "str:lastValidAuctionId": "1",
                         "str:auctionById|u64:1": ""
                     },

--- a/esdt-nft-marketplace/src/storage.rs
+++ b/esdt-nft-marketplace/src/storage.rs
@@ -5,7 +5,7 @@ use crate::auction::*;
 #[elrond_wasm::module]
 pub trait StorageModule {
     #[view(getMarketplaceCutPercentage)]
-    #[storage_mapper("bidCutPerecentage")]
+    #[storage_mapper("bidCutPercentage")]
     fn bid_cut_percentage(&self) -> SingleValueMapper<Self::Storage, Self::BigUint>;
 
     #[storage_mapper("auctionById")]


### PR DESCRIPTION
Related to:
https://github.com/ElrondNetwork/arwen-wasm-vm/pull/400
