### PR TITLE
Fix typo in min bid >= max bid error message

### DIFF
--- a/esdt-nft-marketplace/src/marketplace_main.rs
+++ b/esdt-nft-marketplace/src/marketplace_main.rs
@@ -69,7 +69,7 @@ pub trait EsdtNftMarketplace:
         }
 
         let opt_max_bid = if max_bid > 0u32 {
-            require!(min_bid <= max_bid, "Min bid can't higher than max bid");
+            require!(min_bid <= max_bid, "Min bid can't be higher than max bid");
 
             Some(max_bid)
         } else {


### PR DESCRIPTION
 Fix typo in error message when min bid is higher than max bid