### PR TITLE
Offer feature + min delta bid check + wasm 0.30.0

### DIFF
--- a/esdt-nft-marketplace/Cargo.toml
+++ b/esdt-nft-marketplace/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 path = "src/marketplace_main.rs"
 
 [dependencies.elrond-wasm]
-version = "0.29.2"
+version = "0.30.0"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.29.2"
+version = "0.30.0"

--- a/esdt-nft-marketplace/meta/Cargo.toml
+++ b/esdt-nft-marketplace/meta/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.29.2"
+version = "0.30.0"
 
 [dependencies.elrond-wasm-debug]
-version = "0.29.2"
+version = "0.30.0"

--- a/esdt-nft-marketplace/src/auction.rs
+++ b/esdt-nft-marketplace/src/auction.rs
@@ -10,6 +10,7 @@ pub struct Auction<M: ManagedTypeApi> {
     pub payment_token: EsdtToken<M>,
     pub min_bid: BigUint<M>,
     pub max_bid: Option<BigUint<M>>,
+    pub min_bid_diff: BigUint<M>,
     pub start_time: u64,
     pub deadline: u64,
 
@@ -28,7 +29,7 @@ pub enum AuctionType {
     SftOnePerPayment,
 }
 
-#[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, TypeAbi, Clone)]
+#[derive(ManagedVecItem, TopEncode, TopDecode, NestedEncode, NestedDecode, TypeAbi, Clone)]
 pub struct EsdtToken<M: ManagedTypeApi> {
     pub token_type: TokenIdentifier<M>,
     pub nonce: u64,

--- a/esdt-nft-marketplace/src/events.rs
+++ b/esdt-nft-marketplace/src/events.rs
@@ -1,6 +1,8 @@
 elrond_wasm::imports!();
 elrond_wasm::derive_imports!();
 
+use crate::offer::Offer;
+
 use super::auction::{Auction, AuctionType};
 
 #[allow(clippy::too_many_arguments)]
@@ -72,6 +74,54 @@ pub trait EventsModule {
         );
     }
 
+    fn emit_offer_token_event(self, offer_id: u64, offer: Offer<Self::Api>) {
+        self.offer_token_event(
+            offer_id,
+            &offer.offer_token.token_type,
+            offer.offer_token.nonce,
+            &offer.payment_token.token_type,
+            offer.payment_token.nonce,
+            &offer.offer_owner,
+            &offer.offer_price,
+            offer.start_time,
+            offer.deadline,
+        )
+    }
+
+    fn emit_withdraw_offer_event(self, offer_id: u64, offer: Offer<Self::Api>) {
+        self.withdraw_offer_token_event(
+            offer_id,
+            &offer.offer_token.token_type,
+            offer.offer_token.nonce,
+            &offer.offer_owner,
+            &offer.offer_price,
+            offer.start_time,
+            offer.deadline,
+        )
+    }
+
+    fn emit_accept_offer_event(
+        self,
+        offer_id: u64,
+        offer: Offer<Self::Api>,
+        seller: &ManagedAddress,
+    ) {
+        self.accept_offer_token_event(
+            offer_id,
+            &offer.offer_token.token_type,
+            offer.offer_token.nonce,
+            &offer.payment_token.token_type,
+            offer.payment_token.nonce,
+            &offer.offer_owner,
+            &seller,
+            &offer.offer_price,
+            offer.start_time,
+            offer.deadline,
+            &offer.marketplace_cut_percentage,
+            &offer.creator_royalties_percentage,
+        )
+    }
+
     #[event("auction_token_event")]
     fn auction_token_event(
         &self,
@@ -131,5 +181,48 @@ pub trait EventsModule {
         #[indexed] auction_id: u64,
         #[indexed] nr_auctioned_tokens: &BigUint,
         #[indexed] seller: &ManagedAddress,
+    );
+
+    #[event("offer_token_event")]
+    fn offer_token_event(
+        &self,
+        #[indexed] offer_id: u64,
+        #[indexed] offer_token_id: &TokenIdentifier,
+        #[indexed] offer_token_nonce: u64,
+        #[indexed] payment_token_type: &TokenIdentifier,
+        #[indexed] payment_token_nonce: u64,
+        #[indexed] buyer: &ManagedAddress,
+        #[indexed] offer_price: &BigUint,
+        #[indexed] start_time: u64,
+        #[indexed] deadline: u64,
+    );
+
+    #[event("withdraw_offer_token_event")]
+    fn withdraw_offer_token_event(
+        &self,
+        #[indexed] offer_id: u64,
+        #[indexed] offer_token_id: &TokenIdentifier,
+        #[indexed] offer_token_nonce: u64,
+        #[indexed] buyer: &ManagedAddress,
+        #[indexed] offer_price: &BigUint,
+        #[indexed] start_time: u64,
+        #[indexed] deadline: u64,
+    );
+
+    #[event("accept_offer_token_event")]
+    fn accept_offer_token_event(
+        &self,
+        #[indexed] offer_id: u64,
+        #[indexed] offer_token_id: &TokenIdentifier,
+        #[indexed] offer_token_nonce: u64,
+        #[indexed] payment_token_type: &TokenIdentifier,
+        #[indexed] payment_token_nonce: u64,
+        #[indexed] buyer: &ManagedAddress,
+        #[indexed] seller: &ManagedAddress,
+        #[indexed] offer_price: &BigUint,
+        #[indexed] start_time: u64,
+        #[indexed] deadline: u64,
+        #[indexed] marketplace_cut_percentage: &BigUint,
+        #[indexed] creator_royalties_percentage: &BigUint,
     );
 }

--- a/esdt-nft-marketplace/src/marketplace_main.rs
+++ b/esdt-nft-marketplace/src/marketplace_main.rs
@@ -1,9 +1,12 @@
 #![no_std]
+#![feature(generic_associated_types)]
 
 elrond_wasm::imports!();
 
 pub mod auction;
 use auction::*;
+pub mod offer;
+use offer::*;
 
 mod events;
 mod storage;
@@ -46,10 +49,16 @@ pub trait EsdtNftMarketplace:
         #[var_args] opt_accepted_payment_token_nonce: OptionalValue<u64>,
         #[var_args] opt_sft_max_one_per_payment: OptionalValue<bool>,
         #[var_args] opt_start_time: OptionalValue<u64>,
+        #[var_args] opt_min_bid_diff: OptionalValue<BigUint>,
     ) -> u64 {
         require!(
             nft_amount >= BigUint::from(NFT_AMOUNT),
             "Must tranfer at least one"
+        );
+
+        require!(
+            self.auctions_by_token(&nft_type, nft_nonce).is_empty(),
+            "An auction for this token already exists"
         );
 
         let current_time = self.blockchain().get_block_timestamp();
@@ -95,6 +104,11 @@ pub trait EsdtNftMarketplace:
             "Marketplace cut plus royalties exceeds 100%"
         );
 
+        let min_bid_diff = match opt_min_bid_diff {
+            OptionalValue::Some(min_diff) => min_diff,
+            OptionalValue::None => BigUint::zero(),
+        };
+
         let accepted_payment_nft_nonce = if accepted_payment_token.is_egld() {
             0
         } else {
@@ -117,7 +131,7 @@ pub trait EsdtNftMarketplace:
 
         let auction = Auction {
             auctioned_token: EsdtToken {
-                token_type: nft_type,
+                token_type: nft_type.clone(),
                 nonce: nft_nonce,
             },
             nr_auctioned_tokens: nft_amount,
@@ -129,6 +143,7 @@ pub trait EsdtNftMarketplace:
             },
             min_bid,
             max_bid: opt_max_bid,
+            min_bid_diff,
             start_time,
             deadline,
 
@@ -138,7 +153,12 @@ pub trait EsdtNftMarketplace:
             marketplace_cut_percentage,
             creator_royalties_percentage,
         };
+
         self.auction_by_id(auction_id).set(&auction);
+        self.auctions_by_token(&nft_type, nft_nonce)
+            .insert(auction_id);
+        self.auctions_by_address(&auction.original_owner)
+            .insert(auction_id);
 
         self.emit_auction_token_event(auction_id, auction);
 
@@ -197,6 +217,13 @@ pub trait EsdtNftMarketplace:
             require!(
                 &payment_amount <= max_bid,
                 "Bid must be less than or equal to the max bid"
+            );
+        }
+
+        if &auction.min_bid_diff > &BigUint::zero() {
+            require!(
+                (&payment_amount - &auction.current_bid) >= auction.min_bid_diff,
+                "The difference from the last bid must be higher"
             );
         }
 
@@ -317,7 +344,7 @@ pub trait EsdtNftMarketplace:
     }
 
     #[endpoint]
-    fn withdraw(&self, auction_id: u64) {
+    fn withdraw_auction(&self, auction_id: u64) {
         let auction = self.try_get_auction(auction_id);
         let caller = self.blockchain().get_caller();
 
@@ -330,11 +357,14 @@ pub trait EsdtNftMarketplace:
             "Can't withdraw, NFT already has bids"
         );
 
-        self.auction_by_id(auction_id).clear();
-
         let nft_type = &auction.auctioned_token.token_type;
         let nft_nonce = auction.auctioned_token.nonce;
         let nft_amount = &auction.nr_auctioned_tokens;
+
+        self.auction_by_id(auction_id).clear();
+        self.auctions_by_token(&nft_type, nft_nonce)
+            .remove(&auction_id);
+        self.auctions_by_address(&caller).remove(&auction_id);
         self.transfer_or_save_payment(&caller, nft_type, nft_nonce, nft_amount, b"returned token");
 
         self.emit_withdraw_event(auction_id, auction);
@@ -378,6 +408,203 @@ pub trait EsdtNftMarketplace:
         (egld_payment_amount, output_payments).into()
     }
 
+    #[payable("*")]
+    #[endpoint(sendOffer)]
+    fn send_offer(
+        &self,
+        #[payment_token] payment_token: TokenIdentifier,
+        #[payment_nonce] payment_token_nonce: u64,
+        #[payment_amount] payment_amount: BigUint,
+        nft_type: TokenIdentifier,
+        nft_nonce: u64,
+        nft_amount: BigUint,
+        deadline: u64,
+    ) -> u64 {
+        require!(nft_nonce > 0, "Can't place offers for fungible tokens");
+        require!(
+            nft_amount == BigUint::from(NFT_AMOUNT),
+            "The quantity must be equal to 1!"
+        );
+
+        let current_time = self.blockchain().get_block_timestamp();
+        let caller = self.blockchain().get_caller();
+
+        if !payment_token.is_egld() {
+            require!(
+                payment_token.is_valid_esdt_identifier(),
+                "The payment token is not valid!"
+            );
+        }
+        require!(
+            nft_type.is_valid_esdt_identifier(),
+            "The NFT token is not valid!"
+        );
+        require!(
+            !self
+                .offer_exists(&caller, &nft_type, nft_nonce, &payment_token)
+                .get(),
+            "Offer already exists!"
+        );
+
+        require!(deadline > current_time, "Deadline can't be in the past!");
+
+        let marketplace_cut_percentage = self.bid_cut_percentage().get();
+        let creator_royalties_percentage = self.get_nft_info(&nft_type, nft_nonce).royalties;
+
+        let offer_id = self.last_valid_offer_id().get() + 1;
+        self.last_valid_offer_id().set(&offer_id);
+
+        let offer = Offer {
+            offer_token: EsdtToken {
+                token_type: nft_type,
+                nonce: nft_nonce,
+            },
+            payment_token: EsdtToken {
+                token_type: payment_token,
+                nonce: payment_token_nonce,
+            },
+            quantity: nft_amount,
+            offer_price: payment_amount,
+            start_time: current_time,
+            deadline,
+            offer_owner: caller,
+            marketplace_cut_percentage,
+            creator_royalties_percentage,
+        };
+
+        self.offer_by_id(offer_id).set(&offer);
+        self.offers_by_address(&offer.offer_owner).insert(offer_id);
+        self.offers_by_token(&offer.offer_token.token_type, nft_nonce)
+            .insert(offer_id);
+
+        self.emit_offer_token_event(offer_id, offer);
+
+        offer_id
+    }
+
+    #[endpoint(withdrawOffer)]
+    fn withdraw_offer(&self, offer_id: u64) {
+        let offer = self.try_get_offer(offer_id);
+        let caller = self.blockchain().get_caller();
+
+        require!(
+            offer.offer_owner == caller,
+            "Only the address that placed the offer can withdraw it!"
+        );
+
+        self.send().direct(
+            &caller,
+            &offer.payment_token.token_type,
+            offer.payment_token.nonce,
+            &offer.offer_price,
+            self.get_transfer_data(&caller, b"Withdraw offer!"),
+        );
+
+        self.offer_exists(
+            &offer.offer_owner,
+            &offer.offer_token.token_type,
+            offer.offer_token.nonce,
+            &offer.payment_token.token_type,
+        )
+        .clear();
+        self.offers_by_token(&offer.offer_token.token_type, offer.offer_token.nonce)
+            .remove(&offer_id);
+        self.offers_by_address(&offer.offer_owner).remove(&offer_id);
+        self.offer_by_id(offer_id).clear();
+
+        self.emit_withdraw_offer_event(offer_id, offer);
+    }
+
+    #[payable("*")]
+    #[endpoint(acceptOffer)]
+    fn accept_offer(
+        &self,
+        #[payment_token] nft_token: TokenIdentifier,
+        #[payment_nonce] nft_token_nonce: u64,
+        #[payment_amount] nft_amount: BigUint,
+        offer_id: u64,
+    ) {
+        let offer = self.try_get_offer(offer_id);
+        let seller = self.blockchain().get_caller();
+        let current_time = self.blockchain().get_block_timestamp();
+        require!(current_time <= offer.deadline, "Offer has expired!");
+        require!(offer.offer_owner != seller, "Cannot accept your own offer!");
+
+        require!(
+            nft_token == offer.offer_token.token_type,
+            "The sent token type is different from the offer!"
+        );
+        require!(
+            nft_token_nonce == offer.offer_token.nonce,
+            "The sent token nonce is different from the offer!"
+        );
+        require!(
+            nft_amount == offer.quantity,
+            "The number of tokens sent is different from the offer!"
+        );
+
+        let has_no_active_auctions = self
+            .auctions_by_token(&nft_token, nft_token_nonce)
+            .is_empty();
+
+        // if an NFT is bought, all the active auctions will be canceled
+        if !has_no_active_auctions {
+            self.clear_auctions_for_token(&nft_token, nft_token_nonce);
+        };
+
+        let token_info = self.get_nft_info(&offer.offer_token.token_type, offer.offer_token.nonce);
+        let creator_royalties_percentage = token_info.royalties;
+        require!(
+            &offer.marketplace_cut_percentage + &creator_royalties_percentage < PERCENTAGE_TOTAL,
+            "Marketplace cut plus royalties exceeds 100%"
+        );
+
+        self.transfer_or_save_payment(
+            &offer.offer_owner,
+            &offer.offer_token.token_type,
+            offer.offer_token.nonce,
+            &offer.quantity,
+            b"Token bought!",
+        );
+
+        let offer_split_amounts = self.calculate_accepted_offer_split(&offer);
+        let marketplace_owner = self.blockchain().get_owner_address();
+
+        // NFT marketplace revenue
+        self.transfer_or_save_payment(
+            &marketplace_owner,
+            &offer.payment_token.token_type,
+            offer.payment_token.nonce,
+            &offer_split_amounts.marketplace,
+            b"Marketplace sale fees!",
+        );
+
+        // NFT creator revenue
+        self.transfer_or_save_payment(
+            &token_info.creator,
+            &offer.payment_token.token_type,
+            offer.payment_token.nonce,
+            &offer_split_amounts.creator,
+            b"Creator royalties!",
+        );
+
+        // NFT seller revenue
+        self.transfer_or_save_payment(
+            &seller,
+            &offer.payment_token.token_type,
+            offer.payment_token.nonce,
+            &offer_split_amounts.seller,
+            b"Token sold!",
+        );
+
+        self.offers_by_token(&offer.payment_token.token_type, offer.payment_token.nonce)
+            .remove(&offer_id);
+        self.offers_by_address(&offer.offer_owner).remove(&offer_id);
+        self.offer_by_id(offer_id).clear();
+
+        self.emit_accept_offer_event(offer_id, offer, &seller);
+    }
+
     // private
 
     fn try_get_auction(&self, auction_id: u64) -> Auction<Self::Api> {
@@ -386,6 +613,11 @@ pub trait EsdtNftMarketplace:
             "Auction does not exist"
         );
         self.auction_by_id(auction_id).get()
+    }
+
+    fn try_get_offer(&self, offer_id: u64) -> Offer<Self::Api> {
+        require!(self.does_offer_exist(offer_id), "Offer does not exist!");
+        self.offer_by_id(offer_id).get()
     }
 
     fn calculate_cut_amount(&self, total_amount: &BigUint, cut_percentage: &BigUint) -> BigUint {
@@ -407,6 +639,25 @@ pub trait EsdtNftMarketplace:
         BidSplitAmounts {
             creator: creator_royalties,
             marketplace: bid_cut_amount,
+            seller: seller_amount_to_send,
+        }
+    }
+
+    fn calculate_accepted_offer_split(
+        &self,
+        offer: &Offer<Self::Api>,
+    ) -> BidSplitAmounts<Self::Api> {
+        let creator_royalties =
+            self.calculate_cut_amount(&offer.offer_price, &offer.creator_royalties_percentage);
+        let offer_cut_amount =
+            self.calculate_cut_amount(&offer.offer_price, &offer.marketplace_cut_percentage);
+        let mut seller_amount_to_send = offer.offer_price.clone();
+        seller_amount_to_send -= &creator_royalties;
+        seller_amount_to_send -= &offer_cut_amount;
+
+        BidSplitAmounts {
+            creator: creator_royalties,
+            marketplace: offer_cut_amount,
             seller: seller_amount_to_send,
         }
     }
@@ -498,6 +749,14 @@ pub trait EsdtNftMarketplace:
         }
     }
 
+    fn get_transfer_data(&self, address: &ManagedAddress, data: &'static [u8]) -> &[u8] {
+        if self.blockchain().is_smart_contract(address) {
+            &[]
+        } else {
+            data
+        }
+    }
+
     fn get_nft_info(&self, nft_type: &TokenIdentifier, nft_nonce: u64) -> EsdtTokenData<Self::Api> {
         self.blockchain().get_esdt_token_data(
             &self.blockchain().get_sc_address(),
@@ -514,5 +773,25 @@ pub trait EsdtNftMarketplace:
 
         self.bid_cut_percentage()
             .set(&BigUint::from(new_cut_percentage));
+    }
+
+    fn clear_auctions_for_token(&self, nft_token: &TokenIdentifier, nft_token_nonce: u64) {
+        for auction_id in self.auctions_by_token(&nft_token, nft_token_nonce).iter() {
+            let auction = self.try_get_auction(auction_id);
+            require!(
+                &auction.auctioned_token.token_type == nft_token,
+                "The auctioned token does not match the offer!"
+            );
+            require!(
+                auction.auctioned_token.nonce == nft_token_nonce,
+                "The auctioned token nonce does not match the offer!"
+            );
+            require!(
+                auction.nr_auctioned_tokens == BigUint::from(NFT_AMOUNT),
+                "The token amount for sale is higher than 1!"
+            );
+
+            self.withdraw_auction(auction_id);
+        }
     }
 }

--- a/esdt-nft-marketplace/src/offer.rs
+++ b/esdt-nft-marketplace/src/offer.rs
@@ -1,0 +1,17 @@
+elrond_wasm::imports!();
+elrond_wasm::derive_imports!();
+
+use crate::auction::EsdtToken;
+
+#[derive(ManagedVecItem, TopEncode, TopDecode, NestedEncode, NestedDecode, TypeAbi, Clone)]
+pub struct Offer<M: ManagedTypeApi> {
+    pub offer_token: EsdtToken<M>,
+    pub payment_token: EsdtToken<M>,
+    pub quantity: BigUint<M>,
+    pub offer_price: BigUint<M>,
+    pub start_time: u64,
+    pub deadline: u64,
+    pub offer_owner: ManagedAddress<M>,
+    pub marketplace_cut_percentage: BigUint<M>,
+    pub creator_royalties_percentage: BigUint<M>,
+}

--- a/esdt-nft-marketplace/src/storage.rs
+++ b/esdt-nft-marketplace/src/storage.rs
@@ -1,6 +1,6 @@
 elrond_wasm::imports!();
 
-use crate::auction::*;
+use crate::{auction::*, offer::Offer};
 
 #[elrond_wasm::module]
 pub trait StorageModule {
@@ -23,4 +23,37 @@ pub trait StorageModule {
         token_id: &TokenIdentifier,
         token_nonce: u64,
     ) -> SingleValueMapper<BigUint>;
+
+    #[view(getAuctionsByAddress)]
+    #[storage_mapper("auctionsByAddress")]
+    fn auctions_by_address(&self, address: &ManagedAddress) -> SetMapper<u64>;
+
+    #[view(getAuctionsByToken)]
+    #[storage_mapper("auctionsByToken")]
+    fn auctions_by_token(&self, token_id: &TokenIdentifier, token_nonce: u64) -> SetMapper<u64>;
+
+    #[view(getLastValidOfferId)]
+    #[storage_mapper("lastValidOfferId")]
+    fn last_valid_offer_id(&self) -> SingleValueMapper<u64>;
+
+    #[storage_mapper("offerById")]
+    fn offer_by_id(&self, offer_id: u64) -> SingleValueMapper<Offer<Self::Api>>;
+
+    #[view(getOffersByAddress)]
+    #[storage_mapper("offersByAddress")]
+    fn offers_by_address(&self, address: &ManagedAddress) -> SetMapper<u64>;
+
+    #[view(getOffersByToken)]
+    #[storage_mapper("offersByToken")]
+    fn offers_by_token(&self, token_id: &TokenIdentifier, token_nonce: u64) -> SetMapper<u64>;
+
+    #[view(getOfferExists)]
+    #[storage_mapper("offerExists")]
+    fn offer_exists(
+        &self,
+        address: &ManagedAddress,
+        nft: &TokenIdentifier,
+        nonce: u64,
+        payment_token: &TokenIdentifier,
+    ) -> SingleValueMapper<bool>;
 }

--- a/esdt-nft-marketplace/src/views.rs
+++ b/esdt-nft-marketplace/src/views.rs
@@ -9,6 +9,11 @@ pub trait ViewsModule: crate::storage::StorageModule {
         !self.auction_by_id(auction_id).is_empty()
     }
 
+    #[view(doesOfferExist)]
+    fn does_offer_exist(&self, offer_id: u64) -> bool {
+        !self.offer_by_id(offer_id).is_empty()
+    }
+
     #[view(getAuctionedToken)]
     fn get_auctioned_token(
         &self,

--- a/esdt-nft-marketplace/wasm/Cargo.toml
+++ b/esdt-nft-marketplace/wasm/Cargo.toml
@@ -19,10 +19,10 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.29.2"
+version = "0.30.0"
 
 [dependencies.elrond-wasm-output]
-version = "0.29.2"
+version = "0.30.0"
 features = ["wasm-output-mode"]
 
 [workspace]

--- a/esdt-nft-marketplace/wasm/src/lib.rs
+++ b/esdt-nft-marketplace/wasm/src/lib.rs
@@ -7,27 +7,37 @@
 elrond_wasm_node::wasm_endpoints! {
     esdt_nft_marketplace
     (
+        acceptOffer
         auctionToken
         bid
         buySft
         claimTokens
         doesAuctionExist
+        doesOfferExist
         endAuction
         getAuctionType
         getAuctionedToken
+        getAuctionsByAddress
+        getAuctionsByToken
         getClaimableAmount
         getCurrentWinner
         getCurrentWinningBid
         getDeadline
         getFullAuctionData
         getLastValidAuctionId
+        getLastValidOfferId
         getMarketplaceCutPercentage
         getMinMaxBid
+        getOfferExists
+        getOffersByAddress
+        getOffersByToken
         getOriginalOwner
         getPaymentTokenForAuction
         getStartTime
+        sendOffer
         setCutPercentage
-        withdraw
+        withdrawOffer
+        withdraw_auction
     )
 }
 

--- a/seller-contract-mock/Cargo.toml
+++ b/seller-contract-mock/Cargo.toml
@@ -9,10 +9,10 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.elrond-wasm]
-version = "0.29.2"
+version = "0.30.0"
 
 [dependencies.esdt-nft-marketplace]
 path = "../esdt-nft-marketplace"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.29.2"
+version = "0.30.0"

--- a/seller-contract-mock/meta/Cargo.toml
+++ b/seller-contract-mock/meta/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["Dorin Iancu <dorin.iancu@elrond.com>"]
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.29.2"
+version = "0.30.0"
 
 [dependencies.elrond-wasm-debug]
-version = "0.29.2"
+version = "0.30.0"

--- a/seller-contract-mock/wasm/Cargo.toml
+++ b/seller-contract-mock/wasm/Cargo.toml
@@ -24,8 +24,8 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.29.2"
+version = "0.30.0"
 
 [dependencies.elrond-wasm-output]
-version = "0.29.2"
+version = "0.30.0"
 features = [ "wasm-output-mode",]


### PR DESCRIPTION
Added offer feature:

- It allows any user to place an offer on any existing NFT
- The owner can accept the offer and sent the NFT, while receiving his/hers fair share (after creator & marketplace fees deduction)
- The offer can be accepted even if current bids are active, but not if they cannot be withdrawn.
- Events for sending / withdrawing / accepting an offer are saved.

Also, a min delta bid check was added for auctions.