### PR TITLE
fix negative value situation

### DIFF
--- a/esdt-nft-marketplace/src/marketplace_main.rs
+++ b/esdt-nft-marketplace/src/marketplace_main.rs
@@ -496,11 +496,13 @@ pub trait EsdtNftMarketplace:
         amount: &BigUint,
         data: &'static [u8],
     ) {
-        if self.blockchain().is_smart_contract(to) {
-            self.claimable_amount(to, token_id, nonce)
-                .update(|amt| *amt += amount);
-        } else {
-            self.send().direct(to, token_id, nonce, amount, data);
+        if amount > &BigUint::zero() {
+            if self.blockchain().is_smart_contract(to) {
+                self.claimable_amount(to, token_id, nonce)
+                    .update(|amt| *amt += amount);
+            } else {
+                self.send().direct(to, token_id, nonce, amount, data);
+            }
         }
     }
 


### PR DESCRIPTION
Verify that the value is greater than 0 to avoid a "negative value" error.
Marketplace commission and royalties can be 0.